### PR TITLE
enabling github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple browser based fertilizer calculator, created as a demo project in Angular.js
 
-To run:
+View [fertangular on GitHub pages](http://tjamescorcoran.github.io/fertangular/) or run locally:
 
   cd <here> ; python -m SimpleHTTPServer 8000
 


### PR DESCRIPTION
Adds link from README to GitHub Pages site.  If you merge the change, you still need to create a branch called "gh-pages" to enable the GitHub Pages site.
